### PR TITLE
Fixes for supporting Django 1.8

### DIFF
--- a/easydump/management/commands/load_dump.py
+++ b/easydump/management/commands/load_dump.py
@@ -12,10 +12,16 @@ class Command(EasyDumpCommand):
     """
     Retrieve a dump file from S3, then apply it to the database
     """
+
+    def add_arguments(self, parser):
+        parser.add_argument('--manifest', '-m', type=str, default='default',
+                            help="The manifest to load as specified in "
+                                 "EASYDUMP_MANIFESTS [default='default']")
+
     def handle(self, *args, **options):
         
         # get manifest
-        dump = args[0]
+        dump = options['manifest']
         manifest = self.get_manifest(dump)
         
         # get the key for the correct dump (the latest one)

--- a/easydump/management/commands/make_dump.py
+++ b/easydump/management/commands/make_dump.py
@@ -10,9 +10,14 @@ from easydump.utils import human_size, progress_callback
 
 class Command(EasyDumpCommand):
 
+    def add_arguments(self, parser):
+        parser.add_argument('--manifest', '-m', type=str, default='default',
+                            help="The manifest to load as specified in "
+                                 "EASYDUMP_MANIFESTS [default='default']")
+
     def handle(self, *args, **options):
-        
-        dump = args[0]
+
+        dump = options['manifest']
         manifest = self.get_manifest(dump)
         
         # do the dump only if it already hasn't been done yet

--- a/easydump/management/commands/rotate_dumps.py
+++ b/easydump/management/commands/rotate_dumps.py
@@ -24,7 +24,7 @@ class Command(EasyDumpCommand):
         keys = manifest.bucket.get_all_keys()
         
         for key in keys:
-            dt = parser.parse(key.key)
+            dt = parser.parse(key.key.split('|')[1])
             
             is_2_weeks_old = dt < two_weeks_ago
             is_3_months_old = dt < three_months_ago

--- a/easydump/management/commands/rotate_dumps.py
+++ b/easydump/management/commands/rotate_dumps.py
@@ -32,11 +32,11 @@ class Command(EasyDumpCommand):
             
             if is_2_weeks_old:
                 if is_monday_9PM:
-                    log.debug("keep:", dt)
+                    log.debug("keep: %s", dt)
                 else:
-                    log.debug("delete:", dt)
+                    log.debug("delete: %s", dt)
                     key.delete()
             else:
-                log.info("keep:", dt)
+                log.info("keep: %s", dt)
         
         log.info("Log Rotation Complete.")

--- a/easydump/management/commands/rotate_dumps.py
+++ b/easydump/management/commands/rotate_dumps.py
@@ -7,10 +7,15 @@ from dateutil import parser
 from easydump.mixins import EasyDumpCommand
 
 class Command(EasyDumpCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('--manifest', '-m', type=str, default='default',
+                            help="The manifest to load as specified in "
+                                 "EASYDUMP_MANIFESTS [default='default']")
     
     def handle(self, *args, **options):
         
-        dump = options['dump']
+        dump = options['manifest']
         manifest = self.get_manifest(dump)
         
         two_weeks_ago = datetime.now() - timedelta(days=14)

--- a/easydump/management/commands/rotate_dumps.py
+++ b/easydump/management/commands/rotate_dumps.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import timedelta, datetime
 import logging
 log = logging.getLogger(__name__)
 

--- a/easydump/mixins.py
+++ b/easydump/mixins.py
@@ -2,7 +2,7 @@ import os
 from optparse import make_option
 
 from django.conf import settings
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from django.db import models
 
 from boto.s3.connection import S3Connection
@@ -81,7 +81,7 @@ class Manifest(object):
 
         return set(dump_tables + self.extra_tables)
 
-class EasyDumpCommand(NoArgsCommand):
+class EasyDumpCommand(BaseCommand):
     """
     Common methods for all dump commands
     """


### PR DESCRIPTION
Django 1.8 changed the the way it handles command line arguments and now as a preference for named parameters. Therefore the following form is now used:

```
django-admin make_dump -m foo
django-admin make_dump --manifest=foo
```

If omitted, manifest we default to 'default'.

Also fixes errors in rotate_dumps