### PR TITLE
Adding --drop option for load_dump command [Requires Django 1.8 PR, #3]

### DIFF
--- a/easydump/dumpers.py
+++ b/easydump/dumpers.py
@@ -42,7 +42,29 @@ class Dumper(object):
         
         return self.dump_cmd.format(**vars)
 
+    @classmethod
+    def get_drop_cmd(self, manifest):
+        if not self.drop_cmd:
+            raise NotImplementedError("Sorry, your database type is not supported yet")
+
+        db_name = manifest.database['NAME']
+        db_user = manifest.database['USER']
+        db_host = manifest.database['HOST']
+        db_port = manifest.database['PORT']
+        db_pass = manifest.database['PASSWORD']
+
+        tables = manifest.tables
+
+        if hasattr(self, "format_for_drop"):
+            vars = self.format_for_drop(**locals())
+        else:
+            vars = locals()
+
+        return self.drop_cmd.format(**vars)
+
 class PostgresDumper(Dumper):
+    drop_cmd = 'psql -U {db_user} {db_user} {db_host} {db_port} {db_pass} -c "DROP DATABASE {db_name};"; ' \
+               'psql -U {db_user} {db_user} {db_host} {db_port} {db_pass} -c "CREATE DATABASE {db_name};"'
     restore_cmd = 'pg_restore -U {db_user} {db_host} {db_port} {db_pass} --dbname {db_name} --jobs={jobs} --no-owner easydump'
     dump_cmd = "pg_dump -U {db_user} {db_host} {db_port} {db_pass} --no-acl --clean --oids --no-owner --format=c {tables} {db_name} > easydump"
     
@@ -77,10 +99,25 @@ class PostgresDumper(Dumper):
         
         return kwargs
 
+    @classmethod
+    def format_for_drop(cls, **kwargs):
+        if kwargs['db_pass']:
+            kwargs['db_pass'] = "--password"
+
+        if kwargs['db_port']:
+            kwargs['db_port'] = "-p %s" % kwargs['db_port']
+
+        if kwargs['db_host']:
+            kwargs['db_host'] = "-h %s" % kwargs['db_host']
+
+        return kwargs
+
 class MySQLDumper(Dumper):
+    drop_cmd = None
     restore_cmd = None
     dump_cmd = None
 
 class OracleDumper(Dumper):
+    drop_cmd = None
     restore_cmd = None
     dump_cmd = None

--- a/easydump/management/commands/load_dump.py
+++ b/easydump/management/commands/load_dump.py
@@ -17,6 +17,8 @@ class Command(EasyDumpCommand):
         parser.add_argument('--manifest', '-m', type=str, default='default',
                             help="The manifest to load as specified in "
                                  "EASYDUMP_MANIFESTS [default='default']")
+        parser.add_argument('--drop', '-d', action='store_true',
+                            help="Drop & recreate the database before loading")
 
     def handle(self, *args, **options):
         
@@ -32,7 +34,14 @@ class Command(EasyDumpCommand):
             key.get_contents_to_filename('easydump', cb=progress_callback)
         else:
             log.info('Skipping download because it already has been downloaded')
-        
+
+        # drop if requested
+        if options['drop']:
+            cmd = manifest.drop_cmd
+            log.debug("drop command: %s" % cmd)
+            import pdb; pdb.set_trace()
+            os.system(cmd)
+
         # put into postgres
         cmd = manifest.restore_cmd
         log.debug("restore command: %s" % cmd)

--- a/easydump/mixins.py
+++ b/easydump/mixins.py
@@ -29,6 +29,7 @@ class Manifest(object):
         dumper = self._get_dumper()
         self.dump_cmd = dumper.get_dump_cmd(self)
         self.restore_cmd = dumper.get_restore_cmd(self)
+        self.drop_cmd = dumper.get_drop_cmd(self)
 
     def _get_bucket(self):
         conn = S3Connection(settings.AWS_ACCESS_KEY, settings.AWS_SECRET_KEY)


### PR DESCRIPTION
It is useful for me to be able to dump the entire local DB before loading in a dump. I have therefore added a ``--drop`` option to the ``load_dump`` command.